### PR TITLE
1. feat : Kafka 수신을 위해 이벤트 발행 2개 추가

### DIFF
--- a/ai/src/main/java/ktlibrary/infra/PolicyHandler.java
+++ b/ai/src/main/java/ktlibrary/infra/PolicyHandler.java
@@ -21,12 +21,12 @@ public class PolicyHandler {
     @Autowired
     private StartPublishingService startPublishingService;
 
-    @StreamListener(KafkaProcessor.INPUT)
-    public void whatever(@Payload String eventString) {}
+    // 이벤트가 발행되었는지 확인
+
 
     @StreamListener(
-        value = KafkaProcessor.INPUT,
-        condition = "headers['type']=='PublishingRequested'"
+    value = KafkaProcessor.INPUT,
+    condition = "headers['type']=='PublishingRequested'"
     )
     public void wheneverPublishingRequested_PublishingStarted(
         @Payload PublishingRequested publishingRequested

--- a/ai/src/main/java/ktlibrary/infra/application/service/StartPublishingService.java
+++ b/ai/src/main/java/ktlibrary/infra/application/service/StartPublishingService.java
@@ -41,7 +41,7 @@ public class StartPublishingService {
 
         bookRepository.save(book);
 
-        // PublishingStarted publishingStarted = new PublishingStarted(book);
-        // publishingStarted.publishAfterCommit();
+        PublishingStarted publishingStarted = new PublishingStarted(book);
+        publishingStarted.publishAfterCommit();
     }
 }

--- a/frontend/src/pages/AuthorManuscripts.js
+++ b/frontend/src/pages/AuthorManuscripts.js
@@ -39,11 +39,10 @@ const AuthorManuscripts = () => {
   };
 
   const handlePublish = async (manuscript) => {
-    console.log('📦 출판 요청 직전 데이터:', manuscript);
+    console.log('출판 요청 직전 데이터:', manuscript);
 
     try {
-      await manuscriptAPI.requestPublishing({
-        manuscriptId: manuscript.id,
+      await manuscriptAPI.requestPublishing(manuscript.id, {
         authorName: manuscript.authorName || '알 수 없음',
         authorIntroduction: manuscript.authorIntroduction || '',
       });

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -311,8 +311,8 @@ export const manuscriptAPI = {
   /**
    * 출판 요청 
    */
-  requestPublishing: async (data) => {
-    const url = `${API_CONFIG.gateway}/manuscripts/requestpublishing`; 
+  requestPublishing: async (id, data) => {
+    const url = `${API_CONFIG.gateway}/manuscripts/${id}/requestpublishing`;
     return await apiRequest(url, {
       method: 'POST',
       body: JSON.stringify(data),

--- a/manuscript/src/main/java/ktlibrary/domain/ManuscriptEdited.java
+++ b/manuscript/src/main/java/ktlibrary/domain/ManuscriptEdited.java
@@ -1,0 +1,47 @@
+package ktlibrary.domain;
+
+import ktlibrary.infra.AbstractEvent;
+
+public class ManuscriptEdited extends AbstractEvent {
+
+    private Long id;
+    private Long authorId;
+    private String manuscriptTitle;
+    private String manuscriptContent;
+    private String authorName;
+    private String authorIntroduction;
+
+    public ManuscriptEdited(Manuscript manuscript) {
+        super(manuscript);
+        this.id = manuscript.getId();
+        this.authorId = manuscript.getAuthorId();
+        this.manuscriptTitle = manuscript.getManuscriptTitle();
+        this.manuscriptContent = manuscript.getManuscriptContent();
+        this.authorName = manuscript.getAuthorName();
+        this.authorIntroduction = manuscript.getAuthorIntroduction();
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getAuthorId() {
+        return authorId;
+    }
+
+    public String getManuscriptTitle() {
+        return manuscriptTitle;
+    }
+
+    public String getManuscriptContent() {
+        return manuscriptContent;
+    }
+
+    public String getAuthorName() {
+        return authorName;
+    }
+
+    public String getAuthorIntroduction() {
+        return authorIntroduction;
+    }
+}

--- a/manuscript/src/main/java/ktlibrary/domain/ManuscriptRegistered.java
+++ b/manuscript/src/main/java/ktlibrary/domain/ManuscriptRegistered.java
@@ -1,0 +1,50 @@
+package ktlibrary.domain;
+
+import ktlibrary.infra.AbstractEvent;
+
+public class ManuscriptRegistered extends AbstractEvent {
+
+    private Long id;
+    private Long authorId;
+    private String manuscriptTitle;
+    private String manuscriptContent;
+    private String authorName;              
+    private String authorIntroduction;      
+
+    public ManuscriptRegistered(Manuscript manuscript) {
+        super(manuscript);
+        this.id = manuscript.getId();
+        this.authorId = manuscript.getAuthorId();
+        this.manuscriptTitle = manuscript.getManuscriptTitle();
+        this.manuscriptContent = manuscript.getManuscriptContent();
+        this.authorName = manuscript.getAuthorName();                  
+        this.authorIntroduction = manuscript.getAuthorIntroduction();  
+
+
+    }
+
+    // Getter 추가 (Kafka 직렬화를 위해 필요함)
+    public Long getId() {
+        return id;
+    }
+
+    public Long getAuthorId() {
+        return authorId;
+    }
+
+    public String getManuscriptTitle() {
+        return manuscriptTitle;
+    }
+
+    public String getManuscriptContent() {
+        return manuscriptContent;
+    }
+
+    public String getAuthorName() {
+        return authorName;
+    }
+
+    public String getAuthorIntroduction() {
+        return authorIntroduction;
+    }
+}

--- a/manuscript/src/main/java/ktlibrary/infra/AbstractEvent.java
+++ b/manuscript/src/main/java/ktlibrary/infra/AbstractEvent.java
@@ -29,25 +29,19 @@ public class AbstractEvent {
     }
 
     public void publish() {
-        /**
-         * spring streams 방식
-         */
-        KafkaProcessor processor = ManuscriptApplication.applicationContext.getBean(
-            KafkaProcessor.class
-        );
+        KafkaProcessor processor = ManuscriptApplication.applicationContext.getBean(KafkaProcessor.class);
         MessageChannel outputChannel = processor.outboundTopic();
 
-        outputChannel.send(
+        boolean result = outputChannel.send(
             MessageBuilder
                 .withPayload(this)
-                .setHeader(
-                    MessageHeaders.CONTENT_TYPE,
-                    MimeTypeUtils.APPLICATION_JSON
-                )
+                .setHeader(MessageHeaders.CONTENT_TYPE, MimeTypeUtils.APPLICATION_JSON)
                 .setHeader("type", getEventType())
                 .build()
         );
+
     }
+
 
     public void publishAfterCommit() {
         TransactionSynchronizationManager.registerSynchronization(

--- a/manuscript/src/main/java/ktlibrary/infra/ManuscriptController.java
+++ b/manuscript/src/main/java/ktlibrary/infra/ManuscriptController.java
@@ -64,19 +64,25 @@ public class ManuscriptController {
     }
 
     @RequestMapping(
-        value = "/manuscripts/requestpublishing",
+        value = "/manuscripts/{id}/requestpublishing",
         method = RequestMethod.POST,
         produces = "application/json;charset=UTF-8"
     )
     public Manuscript requestPublishing(
+        @PathVariable("id") Long id,
+        @RequestBody RequestPublishingCommand requestPublishingCommand,
         HttpServletRequest request,
-        HttpServletResponse response,
-        @RequestBody RequestPublishingCommand requestPublishingCommand
+        HttpServletResponse response
     ) throws Exception {
-        System.out.println("##### /manuscript/requestPublishing  called #####");
-        Manuscript manuscript = new Manuscript();
+        System.out.println("##### /manuscript/requestPublishing called #####");
+        
+        Optional<Manuscript> optionalManuscript = manuscriptRepository.findById(id);
+        optionalManuscript.orElseThrow(() -> new Exception("No Manuscript Found"));
+
+        Manuscript manuscript = optionalManuscript.get();
         manuscript.requestPublishing(requestPublishingCommand);
         manuscriptRepository.save(manuscript);
+
         return manuscript;
     }
 }

--- a/manuscript/src/main/resources/application.yml
+++ b/manuscript/src/main/resources/application.yml
@@ -1,19 +1,39 @@
 server:
-  port: 8080
+  port: 8085
 
 spring:
   application:
     name: manuscript
+
 ---
 
 spring:
   profiles: default
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
+      settings:
+        web-allow-others: true
+  datasource:
+    url: jdbc:h2:mem:testdb
+    driver-class-name: org.h2.Driver
+    username: sa
+    password: 
   jpa:
+    database-platform: org.hibernate.dialect.H2Dialect
+    hibernate:
+      ddl-auto: create-drop
+    defer-datasource-initialization: true
     properties:
       hibernate:
         show_sql: true
         format_sql: true
         implicit_naming_strategy: org.hibernate.boot.model.naming.ImplicitNamingStrategyComponentPathImpl
+  sql:
+    init:
+      mode: always
+      encoding: UTF-8
   cloud:
     stream:
       kafka:
@@ -30,14 +50,10 @@ spring:
       bindings:
         event-in:
           group: manuscript
-#<<< EDA / Topic Name
           destination: ktlibrary
-#>>> EDA / Topic Name
           contentType: application/json
         event-out:
-#<<< EDA / Topic Name
           destination: ktlibrary
-#>>> EDA / Topic Name
           contentType: application/json
 
 logging:
@@ -45,20 +61,35 @@ logging:
     org.hibernate.type: trace
     org.springframework.cloud: debug
 
-
-server:
-  port: 8085
-
 ---
 
 spring:
   profiles: docker
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
+      settings:
+        web-allow-others: true
+  datasource:
+    url: jdbc:h2:mem:testdb
+    driver-class-name: org.h2.Driver
+    username: sa
+    password: 
   jpa:
+    database-platform: org.hibernate.dialect.H2Dialect
+    hibernate:
+      ddl-auto: create-drop
+    defer-datasource-initialization: true
     properties:
       hibernate:
         show_sql: true
         format_sql: true
         implicit_naming_strategy: org.hibernate.boot.model.naming.ImplicitNamingStrategyComponentPathImpl
+  sql:
+    init:
+      mode: always
+      encoding: UTF-8
   cloud:
     stream:
       kafka:
@@ -80,5 +111,3 @@ spring:
         event-out:
           destination: ktlibrary
           contentType: application/json
-
-


### PR DESCRIPTION
ManuscriptRegistered, ManuscriptEdited

2. refactor : application.yml

h2 db 추가

**3.**refactor : Manuscript, ManuscriptController, AbstractEvent

1. cqrs 로 작가 정보를 받아오는걸 register에서 처리하게 만듦
2. 수정 부분도 register랑 동일하게 변경
3. 원고 publish 하는 부분 api 수정 (id가 없었음 → id 별로 발행하게 수정)
4. 원고 publish 데이터 수정부분 변경

4. refactor : AuthorManuscripts.js, api.js

백엔드 api 수정한것 프론트에서도 수정함

5. refactor : StartPublishing

- pub/sub 데이터 수신이 완료됐다는 Publishing started 발행(주석제거)
- executePublishing publishing 부분에서 new book을 생성하고 그 객체에 publishing 데이터 매핑하게 변경