### PR TITLE
fix : 출판현황 페이지 목록이 안떴었는데 목록을 볼 수 있도록 수정

### DIFF
--- a/frontend/src/pages/AuthorPublishing.js
+++ b/frontend/src/pages/AuthorPublishing.js
@@ -10,16 +10,17 @@ const AuthorPublishing = () => {
   useEffect(() => {
     const fetch = async () => {
       try {
-        const all = await manuscriptAPI.getAllManuscripts();
+        const response = await manuscriptAPI.getAllManuscripts();
+        const all = response._embedded?.manuscripts ?? [];
         const mine = all.filter((m) => m.authorId === user.id);
-        const publishedList = mine.filter((m) => !!m.authorName); // 출판 요청된 것만
+        const publishedList = mine.filter((m) => !!m.authorName);
         setPublished(publishedList);
       } catch (err) {
         console.error('출판현황 조회 실패:', err.message);
       }
     };
     fetch();
-  }, [user]);
+  }, []); //useEffect 1회 실행
 
   return (
     <div className={styles.container}>


### PR DESCRIPTION
(문제) 
const all = await manuscriptAPI.getAllManuscripts(); const mine = all.filter((m) => m.authorId === user.id); -> 여기서 all 객체가 배열이 아니기 때문에 all.filter를 호출하지 못함
manuscriptAPI.getAllManuscripts()의 응답 형식이 배열이 아니라 객체라서 받아오질 못함

(변경) 
const all = response._embedded?.manuscripts ?? []; -> all._embedded?.manuscripts로 접근하고, 없을 경우 빈 배열로 대체

<img width="1273" alt="출판현황 되도록" src="https://github.com/user-attachments/assets/9a53e520-ddb8-423b-a8b8-c123f11ca56c" />
