### PR TITLE
feat: BookDetailed, BookDetailed.module.css

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -15,6 +15,7 @@ import CustomerPoints from './pages/CustomerPoints';
 import CustomerBooks from './pages/CustomerBooks';
 import HomePage from './pages/HomePage';
 import CustomerBookshelf from './pages/CustomerBookshelf';
+import BookDetailed from './pages/BookDetailed'; 
 
 import './App.css';
 
@@ -190,7 +191,8 @@ function App() {
           <Route path="/customer/subscription" element={<SubscriptionPage />} />
           <Route path="/customer/points" element={<CustomerPoints />} />
           <Route path="/customer/bookshelf" element={<CustomerBookshelf />} />
-          
+          <Route path="/customer/books/:bookId" element={<BookDetailed />} />
+
           {/* 관리자 라우트 */}
           <Route path="/admin" element={<AdminLogin />} />
           <Route path="/admin/authors" element={<AuthorApproval />} />

--- a/frontend/src/pages/BookDetailed.js
+++ b/frontend/src/pages/BookDetailed.js
@@ -1,0 +1,68 @@
+// src/pages/BookDetailed.jsx
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { platformAPI } from '../services/api';
+import styles from '../styles/BookDetailed.module.css';
+
+function BookDetailed() {
+  const { bookId } = useParams();
+  const [book, setBook] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    const fetchBook = async () => {
+      try {
+        const data = await platformAPI.getBookById(bookId);
+        setBook(data);
+        console.log('book 데이터', data); 
+      } catch (err) {
+        setError(err.message || '도서 정보를 가져오는 데 실패했습니다.');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchBook();
+  }, [bookId]);
+
+  if (error) {
+    return <div style={{ padding: '2rem', color: 'red' }}>❌ {error}</div>;
+  }
+
+  if (!book) {
+    return <div style={{ padding: '2rem' }}>도서 정보가 존재하지 않습니다.</div>;
+  }
+
+  return (
+    <div className={styles.card}>
+      <div className={styles.content}>
+        {/* 좌측: 이미지 */}
+        <div className={styles.imageBox}>
+          <img src={book.coverUrl} alt="책 표지" className={styles.coverImage} />
+        </div>
+
+        {/* 우측: 설명 */}
+        <div className={styles.details}>
+          <h2>{book.title}</h2>
+          <p><strong>저자:</strong> {book.authorName}</p>
+          <p><strong>저자 소개:</strong> {book.introduction}</p>
+          <p><strong>카테고리:</strong> {book.category}</p>
+          <p><strong>요약:</strong> {book.summary}</p>
+          <p><strong>가격:</strong> {book.price} 포인트</p>
+          <p><strong>조회수:</strong> {book.viewCount}</p>
+          <p><strong>베스트셀러:</strong> {book.isBestSeller ? '✅' : '❌'}</p>
+        </div>
+      </div>
+
+      {/* 하단: PDF 링크 */}
+      <div className={styles.downloadBox}>
+        <a href={book.fileUrl} target="_blank" rel="noopener noreferrer" download>
+          📥 PDF 파일 다운로드
+        </a>
+      </div>
+    </div>
+  );
+}
+
+export default BookDetailed;

--- a/frontend/src/pages/CustomerBooks.js
+++ b/frontend/src/pages/CustomerBooks.js
@@ -2,12 +2,14 @@ import React, { useState, useEffect } from 'react';
 import BookCard from '../components/BookCard';
 import { platformAPI } from '../services/api';
 import styles from '../styles/CustomerBooks.module.css';
+import { useNavigate } from 'react-router-dom';
 
 const CustomerBooks = () => {
   const [books, setBooks] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [selectedCategory, setSelectedCategory] = useState('전체');
+  const navigate = useNavigate();
 
   useEffect(() => {
     fetchBooks();
@@ -40,12 +42,13 @@ const CustomerBooks = () => {
       await fetchBooks();
       
       // 여기에 도서 상세 페이지로 이동하거나 모달을 띄우는 로직 추가 가능
-      alert(`"${book.title}" 도서를 열람했습니다.`);
-      
+      // alert(`"${book.title}" 도서를 열람했습니다.`);
+      navigate(`/customer/books/${book.id}`);
     } catch (err) {
       console.error('도서 열람 실패:', err);
       alert(err.message || '도서 열람에 실패했습니다.');
     }
+    
   };
 
   // 카테고리별 필터링

--- a/frontend/src/pages/CustomerBookshelf.js
+++ b/frontend/src/pages/CustomerBookshelf.js
@@ -62,8 +62,8 @@ const CustomerBookshelf = () => {
         await fetchMyBooks(user.id);
       }
       
-      alert(`"${book.title}" 도서를 다시 열람했습니다.`);
       
+      navigate(`/customer/books/${book.id}`);
     } catch (err) {
       console.error('도서 열람 실패:', err);
       alert(err.message || '도서 열람에 실패했습니다.');

--- a/frontend/src/pages/HomePage.js
+++ b/frontend/src/pages/HomePage.js
@@ -4,12 +4,13 @@ import BookCard from '../components/BookCard';
 import { platformAPI } from '../services/api';
 import styles from '../styles/CustomerBooks.module.css';
 
+
 const HomePage = () => {
   const navigate = useNavigate();
   const [bestsellerBooks, setBestsellerBooks] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
-  
+
   useEffect(() => {
     fetchBestsellerBooks();
   }, []);
@@ -40,10 +41,10 @@ const HomePage = () => {
       // 도서 정보 새로고침
       await fetchBestsellerBooks();
       
-      alert(`"${book.title}" 도서를 열람했습니다.`);
+      
       
       // 도서 상세 페이지로 이동하려면:
-      // navigate(`/book/${book.id}`);
+      navigate(`/customer/books/${book.id}`);
     } catch (err) {
       console.error('도서 열람 실패:', err);
       alert('도서 열람에 실패했습니다.');

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,6 +1,6 @@
 // API 기본 설정
 const API_CONFIG = {
-  gateway: 'http://130.107.27.223'
+  gateway: "http://130.107.27.223"
 };
 
 /**
@@ -420,7 +420,18 @@ export const platformAPI = {
     return await apiRequest(url, {
       method: 'POST'
     });
+  },
+  
+    /**
+   * 도서 ID로 상세 조회
+   * @param {number} bookId - 도서 ID
+   * @returns {Promise} 도서 상세 정보
+   */
+    getBookById: async (bookId) => {
+      const url = `${API_CONFIG.gateway}/bookShelves/${bookId}`;
+      return await apiRequest(url);
   }
+  
 };
 
 export default {

--- a/frontend/src/styles/BookDetailed.module.css
+++ b/frontend/src/styles/BookDetailed.module.css
@@ -1,0 +1,68 @@
+/* src/styles/BookDetailed.module.css */
+
+.card {
+  max-width: 800px;
+  margin: 2rem auto;
+  padding: 1.5rem;
+  border: 1px solid #ddd;
+  border-radius: 12px;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+  background-color: #fff;
+}
+
+.content {
+  display: flex;
+  gap: 2rem;
+  flex-wrap: wrap;
+}
+
+.imageBox {
+  flex: 1;
+  min-width: 200px;
+}
+
+.coverImage {
+  width: 100%;
+  height: auto;
+  max-width: 220px;
+  border-radius: 8px;
+}
+
+.details {
+  flex: 2;
+  min-width: 300px;
+}
+
+.details h2 {
+  margin-top: 0;
+  color: #333;
+}
+
+.details p {
+  margin: 0.5rem 0;
+  color: #555;
+}
+
+.downloadBox {
+  margin-top: 2rem;
+  text-align: right;
+}
+
+.downloadBox a {
+  text-decoration: none;
+  color: #0077cc;
+  font-weight: bold;
+}
+
+.message {
+  padding: 2rem;
+  text-align: center;
+  color: #555;
+}
+
+.error {
+  padding: 2rem;
+  text-align: center;
+  color: red;
+  font-weight: bold;
+}


### PR DESCRIPTION
feat: BookDetailed, BookDetailed.module.css
1. 책 상세 페이지 추가(BookDetailed)
2. 책 상세 페이지 css파일 추가(BookDetailed.module.css)

refactor: Homepage.js, CustomerBookshelf.js, CustomerBooks.js
1. 라우트 규칙추가
2. 고객페이지, 내서재, 홈페이지에서 -> 상세 페이지로 가는 버튼추가
3. 책 상세를 넘겨주는 api 추가