### PR TITLE
fix: 승인되지 않은 작가 원고등록 방지 오류 수정(AuthorNewManuscript.js)

### DIFF
--- a/frontend/src/components/BookCard.js
+++ b/frontend/src/components/BookCard.js
@@ -24,6 +24,7 @@ const BookCard = ({
   } = book;
 
   const formatPrice = (price) => {
+    if (typeof price !== 'number') return '가격 정보 없음';
     if (price === 0) return '무료';
     return `${price.toLocaleString()}원`;
   };

--- a/frontend/src/pages/AuthorNewManuscript.js
+++ b/frontend/src/pages/AuthorNewManuscript.js
@@ -2,6 +2,7 @@
 import React, { useState, useEffect } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { manuscriptAPI } from '../services/api';
+import { authorAPI } from '../services/api';
 
 const AuthorNewManuscript = () => {
   const location = useLocation();
@@ -25,7 +26,14 @@ const AuthorNewManuscript = () => {
   const handleSubmit = async (e) => {
     e.preventDefault();
     
+    
     try {
+      const author = await authorAPI.getAuthor(user.id);
+      if (!author.isApproved) {
+        alert('승인되지 않은 작가는 원고를 등록할 수 없습니다.');
+        return; // 등록 중단
+      }
+
       const manuscriptData = {
         authorId: user.id,
         authorName: user.name,

--- a/frontend/src/pages/BookDetailed.js
+++ b/frontend/src/pages/BookDetailed.js
@@ -49,7 +49,7 @@ function BookDetailed() {
           <p><strong>저자 소개:</strong> {book.introduction}</p>
           <p><strong>카테고리:</strong> {book.category}</p>
           <p><strong>요약:</strong> {book.summary}</p>
-          <p><strong>가격:</strong> {book.price} 포인트</p>
+          <p><strong>가격:</strong> {book.price}</p>
           <p><strong>조회수:</strong> {book.viewCount}</p>
           <p><strong>베스트셀러:</strong> {book.isBestSeller ? '✅' : '❌'}</p>
         </div>


### PR DESCRIPTION
저번처럼 백엔드에서 잘 못받아오는것 같길래
api.js에서 작가 api를 받아 프론트엔드에서 원고 등록을 방지했습니다.
변경하고 테스트 해봤는데 잘 동작하고, 승인 후에도 동작이 잘 되는것을 확인했습니다

refactor:
1. BookDetailed 오타 수정
2. BookCard null 처리 추가 -> Platform 에서 가격이 null값일때 uncaught 오류가 발생하는걸 방지하고 테스트를 용이하게 하기 위해 null 값 처리를 추가했습니다